### PR TITLE
add trailing empty values to row if data is missing trailing delimiters

### DIFF
--- a/csvtools/csvmerge.py
+++ b/csvtools/csvmerge.py
@@ -54,6 +54,8 @@ def process(csvs, union, delimiter, default_value, filename):
             if len(row) == 0:
               logging.warn('processing %s: empty row. continuing...', csvs[idx])
               break
+            elif len(row) < len(headers_list[idx]):
+              row += [""] * (len(headers_list[idx]) - len(row))
             outline = []
             for val in output_cols: # each colname to include
                 if val == filename:


### PR DESCRIPTION
tried csvmerge with --union with some csvs i downloaded

those csvs trimmed all trailing "," of a row if the last columns did not have values, so the parser did not recognize them as empty values and "row" had less elements than there are columns -> row[headers_list[idx].index(val)] throws an IndexOutOfRangeException